### PR TITLE
fix: fixed build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,14 @@ There is a [collection of ADRs](docs/adr) that document the decisions taken duri
 4. **Run the simulation**:
 
    ```bash
+   npm run build
    npm start
+   ```
+
+5. **Run the simulation (DEV mode)**:
+
+   ```bash
+   npm run dev
    ```
 
 ## Linting, Formatting, and Testing
@@ -92,7 +99,8 @@ A GitHub Actions workflow runs on every push and pull request to ensure that:
 - Add integration tests to ensure the CLI works properly, at the moment there is a test mocking the `prompts` library.
 - Improve error handling and messages, now there is a generic message per input.
 - Generate API documentation, using for example TypeDoc, for all the modules.
-- Add an help functionality for the CLI
+- Improve TS and eslint configs, I tried to use the latest version of eslint (9) but it's having some compatibility issues with TS.
+- Add an help functionality for the CLI.
 - Add pre-commit/pre-push validation using [Husky](https://github.com/typicode/husky)
 
   - enforce conditional commit syntax

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "src/index.ts",
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "build": "tsc src/index.ts --outDir dist --moduleResolution NodeNext --module NodeNext --target ES2022",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
# Overview

Added back the built version of the application.

## What's the purpose of this Pull Request?

Being able to build the application and run it with plain node (without `ts-node`).

## How was this tested?

```bash
npm run build
npm start
```

Everything should work.

## Code Reviewers should be aware of

There are some compatibility issues with the latest version of eslint and the tsconfig.

Inlining the `moduleResolution` and `target`in the `build` script solved the issue, although it's not the best solution.